### PR TITLE
fix: Wayland window resizability by updating Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "electron-store": "8.2.0"
   },
   "devDependencies": {
-    "electron": "33.3.1",
+    "electron": "^33.4.11",
     "electron-builder": "25.1.8",
     "typescript": "5.7.3"
   },


### PR DESCRIPTION
When launched with wayland enabled, the current electron version doesn't allow for window resizing. Updating it returns the option to resize the app